### PR TITLE
Update version and ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.11.1
     hooks:
       - id: ruff
         args: [--fix]

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ This software is released under The GNU General Public License Version
    :target: https://codeclimate.com/github/rgmining/rsd/maintainability
 .. |Test Coverage| image:: https://api.codeclimate.com/v1/badges/6461704a370307ee0d55/test_coverage
    :target: https://codeclimate.com/github/rgmining/rsd/test_coverage
-.. |Release| image:: https://img.shields.io/badge/release-0.3.4-brightgreen.svg
+.. |Release| image:: https://img.shields.io/badge/release-0.3.5-brightgreen.svg
    :target: https://pypi.org/project/rgmining-rsd/
 .. |Logo| image:: https://rgmining.github.io/synthetic/_static/image.png
    :target: https://rgmining.github.io/rsd/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "poetry-core>=2" ]
 
 [project]
 name = "rgmining-rsd"
-version = "0.3.4"
+version = "0.3.5"
 description = "An implementation of Review Spammer Detection algorithm"
 readme = "README.rst"
 keywords = [ "algorithm", "graph", "icdm", "mining", "review" ]
@@ -68,7 +68,7 @@ line-length = 79
 addopts = "--cov=rsd --cov-branch --cov-report=term-missing --cov-report=xml"
 
 [tool.bumpversion]
-current_version = "0.3.4"
+current_version = "0.3.5"
 commit = true
 pre_commit_hooks = [
   "poetry lock",


### PR DESCRIPTION
### Description
- Bumps the project version from `0.3.4` to `0.3.5`.
- Updates the `ruff` pre-commit hook from `v0.11.0` to `v0.11.1` for compatibility with the latest fixes and improvements.

No additional configurations or changes were introduced.